### PR TITLE
Initialize i2c_config_t struct to zero for compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(lis3mdl)
+

--- a/components/esp8266_wrapper/CMakeLists.txt
+++ b/components/esp8266_wrapper/CMakeLists.txt
@@ -1,0 +1,6 @@
+idf_component_register(
+    SRCS "esp8266_wrapper.c"
+    INCLUDE_DIRS "."
+    REQUIRES driver
+)
+

--- a/components/esp8266_wrapper/esp8266_wrapper.c
+++ b/components/esp8266_wrapper/esp8266_wrapper.c
@@ -69,6 +69,7 @@ void gpio_enable (gpio_num_t gpio, const gpio_mode_t mode)
 void i2c_init (int bus, gpio_num_t scl, gpio_num_t sda, uint32_t freq)
 {
     i2c_config_t conf;
+    memset(&conf, 0, sizeof(conf));
     conf.mode = I2C_MODE_MASTER;
     conf.sda_io_num = sda;
     conf.scl_io_num = scl;

--- a/components/lis3mdl/CMakeLists.txt
+++ b/components/lis3mdl/CMakeLists.txt
@@ -1,0 +1,6 @@
+idf_component_register(
+    SRCS "lis3mdl.c"
+    INCLUDE_DIRS "."
+    REQUIRES esp8266_wrapper
+)
+

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "lis3mdl.c"
+                    INCLUDE_DIRS "")

--- a/main/lis3mdl_example.c
+++ b/main/lis3mdl_example.c
@@ -33,8 +33,8 @@
 /* -- use following constants to define the example mode ----------- */
 
 // #define SPI_USED     // if defined SPI is used, otherwise I2C
-#define INT_DATA     // data ready interrupt used
-#define INT_THRESH   // threshold interrupt used
+// #define INT_DATA     // data ready interrupt used
+// #define INT_THRESH   // threshold interrupt used
 
 #if defined(INT_DATA) || defined(INT_THRESH)
 #define INT_USED
@@ -74,13 +74,13 @@
 
 // I2C interface defintions for ESP32 and ESP8266
 #define I2C_BUS       0
-#define I2C_SCL_PIN   22
-#define I2C_SDA_PIN   21
+#define I2C_SCL_PIN   14
+#define I2C_SDA_PIN   13
 #define I2C_FREQ      I2C_FREQ_100K
 
 // interrupt GPIOs defintions for ESP8266 and ESP32
 #define PIN_INT       5
-#define PIN_DRDY      12
+#define PIN_DRDY      4
 
 /* -- user tasks --------------------------------------------------- */
 
@@ -197,8 +197,8 @@ void user_init(void)
     i2c_init (I2C_BUS, I2C_SCL_PIN, I2C_SDA_PIN, I2C_FREQ);
     
     // init the sensor with slave address LIS3MDL_I2C_ADDRESS_2 connected to I2C_BUS.
-    sensor = lis3mdl_init_sensor (I2C_BUS, LIS3MDL_I2C_ADDRESS_1, 0);
-
+    sensor = lis3mdl_init_sensor (I2C_BUS, LIS3MDL_I2C_ADDRESS_2, 0);
+    
     #endif
     
     if (sensor)

--- a/main/lis3mdl_example.c
+++ b/main/lis3mdl_example.c
@@ -33,8 +33,8 @@
 /* -- use following constants to define the example mode ----------- */
 
 // #define SPI_USED     // if defined SPI is used, otherwise I2C
-// #define INT_DATA     // data ready interrupt used
-// #define INT_THRESH   // threshold interrupt used
+#define INT_DATA     // data ready interrupt used
+#define INT_THRESH   // threshold interrupt used
 
 #if defined(INT_DATA) || defined(INT_THRESH)
 #define INT_USED
@@ -74,13 +74,13 @@
 
 // I2C interface defintions for ESP32 and ESP8266
 #define I2C_BUS       0
-#define I2C_SCL_PIN   14
-#define I2C_SDA_PIN   13
+#define I2C_SCL_PIN   22
+#define I2C_SDA_PIN   21
 #define I2C_FREQ      I2C_FREQ_100K
 
 // interrupt GPIOs defintions for ESP8266 and ESP32
 #define PIN_INT       5
-#define PIN_DRDY      4
+#define PIN_DRDY      12
 
 /* -- user tasks --------------------------------------------------- */
 
@@ -197,7 +197,7 @@ void user_init(void)
     i2c_init (I2C_BUS, I2C_SCL_PIN, I2C_SDA_PIN, I2C_FREQ);
     
     // init the sensor with slave address LIS3MDL_I2C_ADDRESS_2 connected to I2C_BUS.
-    sensor = lis3mdl_init_sensor (I2C_BUS, LIS3MDL_I2C_ADDRESS_2, 0);
+    sensor = lis3mdl_init_sensor (I2C_BUS, LIS3MDL_I2C_ADDRESS_1, 0);
 
     #endif
     


### PR DESCRIPTION
Thank you very much for the great lib and the fantastic documentation.

- `clk_flags` was [added](https://github.com/espressif/esp-idf/blob/c13afea635adec735435961270d0894ff46eef85/components/driver/include/driver/i2c.h#L67) to the `i2c_config_t` struct in newer versions of ESP-IDF, breaking current i2c initialization for the esp32.
- Initializing the entire struct ensures that all members, including `clk_flags`, are set to default values for future compatibility. Alternatively setting `conf.clk_flags = 0` also works.