### PR TITLE
Initialize i2c_config_t struct to zero for compatibility - ESP-IDF v4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(lis3mdl)
+

--- a/components/esp8266_wrapper/CMakeLists.txt
+++ b/components/esp8266_wrapper/CMakeLists.txt
@@ -1,0 +1,6 @@
+idf_component_register(
+    SRCS "esp8266_wrapper.c"
+    INCLUDE_DIRS "."
+    REQUIRES driver
+)
+

--- a/components/esp8266_wrapper/esp8266_wrapper.c
+++ b/components/esp8266_wrapper/esp8266_wrapper.c
@@ -69,6 +69,7 @@ void gpio_enable (gpio_num_t gpio, const gpio_mode_t mode)
 void i2c_init (int bus, gpio_num_t scl, gpio_num_t sda, uint32_t freq)
 {
     i2c_config_t conf;
+    memset(&conf, 0, sizeof(conf));
     conf.mode = I2C_MODE_MASTER;
     conf.sda_io_num = sda;
     conf.scl_io_num = scl;

--- a/components/lis3mdl/CMakeLists.txt
+++ b/components/lis3mdl/CMakeLists.txt
@@ -1,0 +1,6 @@
+idf_component_register(
+    SRCS "lis3mdl.c"
+    INCLUDE_DIRS "."
+    REQUIRES esp8266_wrapper
+)
+

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "lis3mdl.c"
+                    INCLUDE_DIRS "")


### PR DESCRIPTION
Thank you very much for the great lib and the fantastic documentation.

- `clk_flags` was [added](https://github.com/espressif/esp-idf/blob/c13afea635adec735435961270d0894ff46eef85/components/driver/include/driver/i2c.h#L67) to the `i2c_config_t` struct in newer versions of ESP-IDF, breaking current i2c initialization for the esp32.
- Initializing the entire struct ensures that all members, including `clk_flags`, are set to default values for future compatibility. Alternatively setting `conf.clk_flags = 0` also works.